### PR TITLE
Use https to load Bootstrap

### DIFF
--- a/templates/bootstrap/body.html
+++ b/templates/bootstrap/body.html
@@ -3,7 +3,7 @@
 <head>
     <title>JSHint Report</title>
 
-    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
 </head>
 <body>
 


### PR DESCRIPTION
Using a protocol-relative URL is unnecessary, and the preferable https protocol should be adopted. In particular, this means that files can be opened under the file:// protocol if they're not on a webserver.

[Paul Irish's post on the subject](http://www.paulirish.com/2010/the-protocol-relative-url/) notes that this is now considered an anti-pattern.