### PR TITLE
Added CSS rule to fix page overflow when there are long lines of code

### DIFF
--- a/templates/bootstrap/body.html
+++ b/templates/bootstrap/body.html
@@ -8,7 +8,7 @@
     <style>
         /* Fix to prevent horizontal overflow when there are long lines of code included in the evidence column */
         code {
-            word-break: break-word;
+            word-break: break-all;
         }
     </style>
 </head>

--- a/templates/bootstrap/body.html
+++ b/templates/bootstrap/body.html
@@ -4,8 +4,8 @@
     <title>JSHint Report</title>
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
-	
-	<style>
+
+    <style>
         /* Fix to prevent horizontal overflow when there are long lines of code included in the evidence column */
         code {
             word-break: break-word;

--- a/templates/bootstrap/body.html
+++ b/templates/bootstrap/body.html
@@ -4,6 +4,13 @@
     <title>JSHint Report</title>
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+	
+	<style>
+        /* Fix to prevent horizontal overflow when there are long lines of code included in the evidence column */
+        code {
+            word-break: break-word;
+        }
+    </style>
 </head>
 <body>
 


### PR DESCRIPTION
<img width="1280" alt="screen shot 2016-10-24 at 12 42 38" src="https://cloud.githubusercontent.com/assets/3789226/19640969/ba64868c-99e7-11e6-997b-07df257522dd.png">

Closes #8 
